### PR TITLE
Destroy Infrastructure via GitHub Actions

### DIFF
--- a/.github/workflows/destroy.yaml
+++ b/.github/workflows/destroy.yaml
@@ -1,0 +1,31 @@
+name: Destroy Infrastructure
+
+on:
+  workflow_dispatch:  # Manually triggered from GitHub Actions UI
+
+jobs:
+  destroy:
+    name: Terraform Destroy
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.3.0
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-north-1
+
+      - name: Initialize Terraform (with S3 backend)
+        run: terraform init -reconfigure
+
+      - name: Destroy Terraform Infrastructure
+        run: terraform destroy -auto-approve


### PR DESCRIPTION
This PR adds a workflow to destroy all Terraform-managed AWS resources using the S3 backend.